### PR TITLE
문서화 및 환경설정 추가

### DIFF
--- a/server/.env.development
+++ b/server/.env.development
@@ -1,4 +1,4 @@
-NODE_ENV=local
+NODE_ENV=development
 PROJECT_NAME=job-play
 
 LOG_DIRECTORY=./_output/logs
@@ -15,7 +15,7 @@ SERVICE_CORES_PORT=3001
 SERVICE_CORES_HEALTH_PORT=3001
 
 MYSQL_HOST=mysql-database
-MYSQL_DATABASE=job-play-local
+MYSQL_DATABASE=job-play-dev
 MYSQL_USER=root
 MYSQL_PASSWORD=root
 MYSQL_PORT=3306

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -12,7 +12,7 @@ RUN pnpm install
 FROM dependencies AS build
 
 COPY . .
-RUN APP_NAME=$APP_NAME npm run build
+RUN APP_NAME=$APP_NAME pnpm run build
 
 # Production stage
 FROM node:22-alpine AS prod

--- a/server/README.md
+++ b/server/README.md
@@ -55,11 +55,11 @@ APP_NAME=cores pnpm run start:dev
   - 린트: `pnpm run lint`
 
 로컬 개발 환경에서는 MySQL 데이터베이스를 사용합니다. MySQL을 사용하려면 Docker를 실행해야 합니다.
-- server 폴더에 .env.local 파일을 생성합니다.
-- .env.local 파일 내에 다음과 같은 내용을 추가합니다.
+- server 폴더에 .env.development 파일을 생성합니다.
+- .env.development 파일 내에 다음과 같은 내용을 추가합니다.
 ```
 MYSQL_HOST=local # 호스트 명에 따라 이름을 변경해줍니다.
-MYSQL_DATABASE=test
+MYSQL_DATABASE=job-play-dev
 MYSQL_ROOT_USER=root
 MYSQL_ROOT_PASSWORD=root
 MYSQL_PORT=3306 # 기본 포트 3306

--- a/server/README.md
+++ b/server/README.md
@@ -54,6 +54,24 @@ APP_NAME=cores pnpm run start:dev
   - 테스트: `pnpm run test`
   - 린트: `pnpm run lint`
 
+로컬 개발 환경에서는 MySQL 데이터베이스를 사용합니다. MySQL을 사용하려면 Docker를 실행해야 합니다.
+- server 폴더에 .env.local 파일을 생성합니다.
+- .env.local 파일 내에 다음과 같은 내용을 추가합니다.
+```
+MYSQL_HOST=local # 호스트 명에 따라 이름을 변경해줍니다.
+MYSQL_DATABASE=test
+MYSQL_ROOT_USER=root
+MYSQL_ROOT_PASSWORD=root
+MYSQL_PORT=3306 # 기본 포트 3306
+```
+Docker mysql 이미지를 다운 받습니다.
+
+```
+docker run -d --name local-jobplay-masql --platform linux/amd64 -p 3306:3306 \
+-e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=job-play-local mysql:8.4.0 \
+--character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+```
+
 ## 프로젝트 구조 예시
 
 ```

--- a/server/docker-compose.yaml
+++ b/server/docker-compose.yaml
@@ -6,7 +6,7 @@ x-logging: &default-logging
 x-apps-common: &apps-common
   profiles: ['apps']
   logging: *default-logging
-  env_file: ./.env.local
+  env_file: ./.env.development
 
 x-mysql-image: &mysql-image
   image: mysql:8.0.22

--- a/server/docker-compose.yaml
+++ b/server/docker-compose.yaml
@@ -44,7 +44,7 @@ services:
       args:
         - APP_NAME=applications
     ports:
-      - "3000:3000"
+      - "3031:3000"
     volumes:
       - ./_output/logs/applications:/app/_output/logs
     healthcheck:
@@ -68,7 +68,7 @@ services:
       args:
         - APP_NAME=cores
     ports:
-      - "3001:3001"
+      - "3032:3001"
     volumes:
       - ./_output/logs/cores:/app/_output/logs
     healthcheck:

--- a/server/scripts/common.cfg
+++ b/server/scripts/common.cfg
@@ -5,7 +5,7 @@ if [ -z "$WORKSPACE_ROOT" ]; then
     exit 1
 fi
 
-ENV_FILE="$WORKSPACE_ROOT/.env.local"
+ENV_FILE="$WORKSPACE_ROOT/.env.development"
 
 . $ENV_FILE
 

--- a/server/scripts/common.cfg
+++ b/server/scripts/common.cfg
@@ -6,6 +6,10 @@ if [ -z "$WORKSPACE_ROOT" ]; then
 fi
 
 ENV_FILE="$WORKSPACE_ROOT/.env.development"
+if [ ! -f "$ENV_FILE" ]; then
+  echo "환경 설정 파일($ENV_FILE)이 없습니다. .env를 생성하거나 경로를 확인하세요."
+  exit 1
+fi
 
 . $ENV_FILE
 

--- a/server/src/apps/shared/config.ts
+++ b/server/src/apps/shared/config.ts
@@ -18,7 +18,7 @@ export const configSchema = Joi.object({
   MYSQL_PORT: Joi.number().required(),
 })
 
-export const isLocal = () => process.env.NODE_ENV === 'local'
+// export const isLocal = () => process.env.NODE_ENV === 'local'
 
 export function generateRandomUUID() {
   return randomUUID().toString().slice(0, 5)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **문서화**
  - 로컬 MySQL 데이터베이스 환경 설정 및 Docker 사용법이 README에 추가되었습니다.
- **신규 기능**
  - 개발 환경용 환경 변수 파일(.env.development)이 추가되었습니다.
- **버그 수정**
  - docker-compose 및 스크립트에서 환경 파일 경로가 .env.local에서 .env.development로 변경되었습니다.
  - .env.development 파일이 없을 경우 오류 메시지가 출력되도록 스크립트가 개선되었습니다.
- **리팩터**
  - Dockerfile에서 빌드 명령어가 npm에서 pnpm으로 변경되었습니다.
  - 불필요한 isLocal 함수의 내보내기가 비활성화되었습니다.
- **스타일**
  - 서비스 포트 매핑이 명확하게 조정되었습니다.
- **기타**
  - 환경 변수 값 일부가 프로젝트명에 맞게 수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->